### PR TITLE
Add account management view.

### DIFF
--- a/src/components/AccountManagement.vue
+++ b/src/components/AccountManagement.vue
@@ -5,6 +5,7 @@ import {
   getAuth,
   onAuthStateChanged,
   signInWithEmailAndPassword,
+  signOut,
   updateProfile,
   User,
 } from 'firebase/auth';
@@ -94,6 +95,10 @@ async function updateName() {
   editingName.value = false;
 }
 
+function logout() {
+  signOut(auth);
+}
+
 // This listener is triggered in two cases:
 // * When the user lands on this page.
 // * When the user deletes their account.
@@ -142,6 +147,9 @@ onBeforeUnmount(() => {
       {{ editingName ? 'Save' : 'Edit' }}
     </button>
   </form>
+  <div class="logout">
+    <button @click="logout">Logout</button>
+  </div>
   <form class="delete-account" @submit.prevent>
     <div class="relogin-password" v-if="showRelogin">
       <label for="password">Password</label>

--- a/src/components/AccountManagement.vue
+++ b/src/components/AccountManagement.vue
@@ -33,10 +33,6 @@ const editingName = ref(false);
 const showRelogin = ref(false);
 
 async function getUserInfo(user: User) {
-  if (email.value) {
-    // Already loaded user info.
-    return;
-  }
   email.value = user.email;
   const docSnap = await getDoc(doc(db, 'users', user.uid));
   if (docSnap.exists()) {
@@ -116,7 +112,7 @@ onBeforeUnmount(() => {
 
 <template>
   <h2>Account Management</h2>
-  <h3>ID and Password</h3>
+  <h3>Email and Password</h3>
   <div class="email">
     <label for="email">Email</label>
     <input name="email" type="text" v-model="email" readonly />

--- a/src/components/AccountManagement.vue
+++ b/src/components/AccountManagement.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import { getApp } from 'firebase/app';
+import {
+  deleteUser,
+  getAuth,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  updateProfile,
+  User,
+} from 'firebase/auth';
+import {
+  doc,
+  deleteDoc,
+  getDoc,
+  getFirestore,
+  setDoc,
+} from 'firebase/firestore';
+import { onBeforeUnmount, ref } from 'vue';
+
+import { router } from '../router';
+
+const auth = getAuth();
+const db = getFirestore(getApp());
+
+// Fields
+const email = ref();
+const firstName = ref();
+const lastName = ref();
+const reloginPassword = ref();
+
+// Toggles
+const editingName = ref(false);
+const showRelogin = ref(false);
+
+async function getUserInfo(user: User) {
+  if (email.value) {
+    // Already loaded user info.
+    return;
+  }
+  email.value = user.email;
+  const docSnap = await getDoc(doc(db, 'users', user.uid));
+  if (docSnap.exists()) {
+    firstName.value = docSnap.data().first_name;
+    lastName.value = docSnap.data().last_name;
+  }
+}
+
+async function deleteAccount() {
+  // If the password hasn't been entered, show the re-login form.
+  if (!reloginPassword.value) {
+    showRelogin.value = true;
+    return;
+  }
+  // If the password has been entered, log in then delete.
+  try {
+    await signInWithEmailAndPassword(auth, email.value, reloginPassword.value);
+  } catch (error) {
+    // TODO: Show errors in UI.
+    console.log(error);
+    return;
+  }
+  try {
+    await deleteDoc(doc(db, 'users', auth.currentUser!.uid));
+    await deleteUser(auth.currentUser!);
+  } catch (error) {
+    // TODO: Show errors in UI.
+    console.log(error);
+  }
+}
+
+async function updateName() {
+  if (!editingName.value) {
+    editingName.value = true;
+    return;
+  }
+  // TODO: Allow users to save if undefined e.g., no name defined initially.
+  // First, update the user profile in Firebase Auth.
+  try {
+    await updateProfile(auth.currentUser!, {
+      displayName: `${firstName.value} ${lastName.value}`,
+    });
+  } catch (error) {
+    // TODO: Show errors in UI.
+    console.log(error);
+    return;
+  }
+  // Then, also update the Firestore entry for the user.
+  try {
+    await setDoc(doc(db, 'users', auth.currentUser!.uid), {
+      first_name: firstName.value,
+      last_name: lastName.value,
+    });
+  } catch (error) {
+    // TODO: Show errors in UI.
+    console.log(error);
+    return;
+  }
+  editingName.value = false;
+}
+
+// This listener is triggered in two cases:
+// * When the user lands on this page.
+// * When the user deletes their account.
+const unsubscribeAuthListener = onAuthStateChanged(auth, (user) => {
+  if (user) {
+    getUserInfo(user);
+  } else {
+    router.push({ path: '/' });
+  }
+});
+
+onBeforeUnmount(() => {
+  unsubscribeAuthListener();
+});
+</script>
+
+<template>
+  <h2>Account Management</h2>
+  <h3>ID and Password</h3>
+  <div class="email">
+    <label for="email">Email</label>
+    <input name="email" type="text" v-model="email" readonly />
+    <RouterLink to="update-email">Edit</RouterLink>
+  </div>
+  <div class="password">
+    <label for="password">Password</label>
+    <input name="password" type="password" readonly />
+    <RouterLink to="reset-password">Reset</RouterLink>
+  </div>
+  <h3>Personal Information</h3>
+  <form class="name" @submit.prevent>
+    <label for="first-name">Name</label>
+    <input
+      name="first-name"
+      type="text"
+      v-model="firstName"
+      :readonly="!editingName"
+    />
+    <input
+      name="last-name"
+      type="text"
+      v-model="lastName"
+      :readonly="!editingName"
+    />
+    <button @click="updateName" type="submit">
+      {{ editingName ? 'Save' : 'Edit' }}
+    </button>
+  </form>
+  <form class="delete-account" @submit.prevent>
+    <div class="relogin-password" v-if="showRelogin">
+      <label for="password">Password</label>
+      <input
+        name="password"
+        type="password"
+        v-model="reloginPassword"
+        required
+      />
+    </div>
+    <button @click="deleteAccount" type="submit">Delete account</button>
+  </form>
+</template>

--- a/src/components/AccountManagement.vue
+++ b/src/components/AccountManagement.vue
@@ -71,7 +71,9 @@ async function updateName() {
     return;
   }
   // TODO: Allow users to save if undefined e.g., no name defined initially.
-  // First, update the user profile in Firebase Auth.
+  // First, update the user profile in Firebase Auth. This field is used for the email
+  // templates.
+  // TODO: Confirm if emails should show full name or first name only.
   try {
     await updateProfile(auth.currentUser!, {
       displayName: `${firstName.value} ${lastName.value}`,
@@ -81,7 +83,9 @@ async function updateName() {
     console.log(error);
     return;
   }
-  // Then, also update the Firestore entry for the user.
+  // Then, also update the Firestore entry for the user. This allows us to store the
+  // first and last names separately.
+  // TODO: Also store organization and location.
   try {
     await setDoc(doc(db, 'users', auth.currentUser!.uid), {
       first_name: firstName.value,

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory, RouteLocation } from 'vue-router';
 
+import AccountManagement from './components/AccountManagement.vue';
 import LogIn from './components/LogIn.vue';
 import LogOut from './components/LogOut.vue';
 import SignUp from './components/SignUp.vue';
@@ -15,9 +16,8 @@ export const router = createRouter({
         redirectUri: route.query.redirect_uri,
       }),
     },
-    // Sign Up
-    { path: '/sign-up', component: SignUp },
-    { path: '/sign-up-check-email', component: SignUpCheckEmail },
+    // Account Management
+    { path: '/account-management', component: AccountManagement },
     // Login
     {
       path: '/login',
@@ -34,5 +34,8 @@ export const router = createRouter({
         redirectUri: route.query.redirect_uri,
       }),
     },
+    // Sign Up
+    { path: '/sign-up', component: SignUp },
+    { path: '/sign-up-check-email', component: SignUpCheckEmail },
   ],
 });


### PR DESCRIPTION
Add account management view.

There are some small differences in behavior from the mocks:
* The first and last names are edited in place instead of on a dedicated page.
* The user is prompted for their password before deleting the account. This is both to confirm the action with the user, and because Firebase requires a recent login for significant actions like deleting the account or changing the email.